### PR TITLE
run goimport for only staged files

### DIFF
--- a/run-goimports.sh
+++ b/run-goimports.sh
@@ -4,5 +4,5 @@
 #
 set -e
 
-output=$(goimports -w .)
+output=$(goimports -w "$@")
 [[ -z "$output" ]]


### PR DESCRIPTION
run with `.` cause apply goimport to current directory. it will cause goimport apply to not the staged files.

with this pr, goimport only apply to staged files.